### PR TITLE
New PHP parser to deal with msgctxt

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,8 @@
     "description": "String extractor for CiviCRM",
     "license": "GPL-2+",
     "require": {
-        "symfony/console": "~2.3"
+        "symfony/console": "~2.3",
+        "nikic/php-parser": "~1.4.1"
     },
     "authors": [
         {

--- a/examples/ex1.php
+++ b/examples/ex1.php
@@ -32,3 +32,6 @@ $s2 = ts('%3 – a plural test, %count frog', array(
 //$s3 = ts('a test – no count', array('plural' => 'No count here'));
 //$s4 = ts('a test – no plural', array('count' => 42));
 $s5 = ts('a test for multitoken element value', array(1 => $c . $d));
+$t1 = ts("This is some text with context", array('context' => 'testcontext'));
+$t2 = ts("This is some text with %1 context", array('context' => 'other_context', 1 => 'more'));
+$t3 = ts("This is some text %1 context", array(1 => 'with even more', 'context' => 'testcontext'));

--- a/examples/ex1.pot
+++ b/examples/ex1.pot
@@ -56,3 +56,18 @@ msgstr[1] ""
 msgid "a test for multitoken element value"
 msgstr ""
 
+#: examples/ex1.php
+msgctxt "testcontext"
+msgid "This is some text with context"
+msgstr ""
+
+#: examples/ex1.php
+msgctxt "other_context"
+msgid "This is some text with %1 context"
+msgstr ""
+
+#: examples/ex1.php
+msgctxt "testcontext"
+msgid "This is some text %1 context"
+msgstr ""
+

--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -2,7 +2,7 @@
 namespace Civi\Strings\Command;
 
 use Civi\Strings\Parser\JsParser;
-use Civi\Strings\Parser\PhpParser;
+use Civi\Strings\Parser\PhpTreeParser;
 use Civi\Strings\Parser\SmartyParser;
 use Civi\Strings\Pot;
 use Symfony\Component\Console\Command\Command;
@@ -57,7 +57,7 @@ class ExtractCommand extends Command {
     $this->parsers = array();
     $this->parsers['js'] = new JsParser();
     $this->parsers['html'] = new JsParser();
-    $this->parsers['php'] = new PhpParser();
+    $this->parsers['php'] = new PhpTreeParser();
     $this->parsers['smarty'] = new SmartyParser($this->parsers['php']);
   }
 

--- a/src/Parser/PhpParser.php
+++ b/src/Parser/PhpParser.php
@@ -22,6 +22,7 @@ define('TS_CALL_TYPE_PLURAL', 2);
  *
  * FIXME Remove fwrite()s
  *
+ * @deprecated see PhpTreeParser
  * @author Jacobo Tarrio <jtarrio [at] alfa21.com>
  * @author Gabor Hojtsy <goba [at] php.net>
  * @author Piotr Szotkowski <shot@caltha.pl>

--- a/src/Parser/PhpTreeParser.php
+++ b/src/Parser/PhpTreeParser.php
@@ -1,0 +1,146 @@
+<?php
+namespace Civi\Strings\Parser;
+
+use Civi\Strings\Pot;
+
+
+/**
+ * ts() calls extractor
+ *
+ * New extractor implementation based on https://github.com/nikic/PHP-Parser
+ *
+ * @author Björn Endres <endres [at] systopia.de>
+ * @copyright 2015
+ * @license http://www.gnu.org/licenses/gpl.html  GNU General Public License
+ */
+class PhpTreeParser implements ParserInterface {
+
+  /**
+   * @param string $file
+   * @param string $code
+   * @param Pot $pot
+   */
+  public function parse($file, $code, Pot $pot) {
+    // Extract raw tokens
+    $lexer = new \PhpParser\Lexer\Emulative();
+    $parser = new \PhpParser\Parser($lexer);
+    try {
+      $stmts = $parser->parse($code);
+      $this->extractStrings(&$stmts, $pot, $file);
+    } catch (PhpParser\Error $e) {
+      $this->reportError("Couldn't parse file: " . $e->getMessage(), 'error', $file);
+    }
+  }
+
+  /**
+   * Recursively searches the tree for ts()-calls
+   *
+   * @param node the AST (abstract syntax tree) node to look into
+   * @param pot  the output POT file object
+   * @param file the filename context
+   */
+  protected function extractStrings(&$node, Pot $pot, &$file) {
+    if (is_array($node)) {
+      foreach ($node as &$single_node) {
+        $this->extractStrings($single_node, $pot, $file);
+      }
+    } elseif (is_object($node)) {
+      if (isset($node->expr)) {
+        $this->extractStrings($node->expr, $pot, $file);
+      }
+      if (isset($node->exprs)) {
+        $this->extractStrings($node->exprs, $pot, $file);
+      }
+      if (isset($node->args)) {
+        $this->extractStrings($node->exprs, $pot, $file);
+      }
+      if (get_class($node) == "PhpParser\Node\Expr\FuncCall" && $node->name->parts[0] == 'ts') {
+        // this is a 'ts' function call
+        $this->createPOTEntry($node, $pot, $file);
+      }
+    } elseif ($node==NULL) {
+      return;
+    } else {
+      $this->reportError("Unknown node type. PhpTreeParser needs to be fixed.", 'warn', $file);
+    }
+  }
+
+  /**
+   * Create a POT entry for the ts()-call AST node
+   *
+   * @param node the AST (abstract syntax tree) node that represents a ts()-call
+   * @param pot  the output POT file object
+   * @param file the filename context
+   */
+  protected function createPOTEntry(&$node, Pot $pot, &$file) {
+    $pot_entry = array(
+      'file'   => $file,
+      'msgstr' => ''
+    );
+
+    // verify the call:
+    if (!isset($node->args[0])) {
+      $this->reportError("ts() call has no arguments.", 'error',  $file);
+      return;
+    }
+
+    if (get_class($node->args[0]->value) != 'PhpParser\Node\Scalar\String_') {
+      $this->reportError("first argument of ts() call is no string.", 'warn',  $file);
+      return;
+    }
+
+    // set the string
+    $pot_entry['msgid'] = $node->args[0]->value->value;
+
+
+    // process the arguments
+    if (isset($node->args[1])) {
+      if (get_class($node->args[1]->value) != 'PhpParser\Node\Expr\Array_') {
+        $this->reportError("second argument of ts() call is not an array.", 'warn',  $file);
+      } else {
+        foreach ($node->args[1]->value->items as &$ts_argument) {
+          switch ($ts_argument->key->value) {
+            case 'domain':
+              $pot_entry['domain'] = $ts_argument->value->value;
+              break;
+
+            case 'plural':
+              // FIXME: Is this really correct or just a workaround? (copied from old implementation)
+              unset($pot_entry['msgstr']);
+              $pot_entry['msgid_plural'] = $ts_argument->value->value;
+              $pot_entry['msgstr[0]'] = '';
+              $pot_entry['msgstr[1]'] = '';
+              break;
+
+            case 'context':
+              $pot_entry['msgctxt'] = $ts_argument->value->value;
+              break;
+            
+            default:
+            case 'count':
+            case 'escape':
+              break;
+          }
+        }
+      }
+    }
+
+    $pot->add($pot_entry);
+  }
+
+  /**
+   * Simple wrapper to report error messages
+   *
+   * @param string message    the error message
+   * @param string level      severity, on of 'error', 'warn', 'info'
+   * @param string reference  location of the error, e.g. the file
+   */
+  protected function reportError($message, $level = 'error', $reference = NULL) {
+    // TODO: find proper sink for error messages
+    if ($reference) {
+      fwrite(STDERR, "[$level] $message ($reference)");
+    } else {
+      fwrite(STDERR, "[$level] $message");
+    }
+  }
+}

--- a/src/Parser/PhpTreeParser.php
+++ b/src/Parser/PhpTreeParser.php
@@ -50,11 +50,10 @@ class PhpTreeParser implements ParserInterface {
       if (get_class($node) == "PhpParser\Node\Expr\FuncCall" && $node->name->parts[0] == 'ts') {
         // this is a 'ts' function call
         $this->createPOTEntry($node, $pot, $file);
-      } else {
-        // else descend into branch
-        foreach ($node as $key => &$value) {
-          $this->extractStrings($value, $pot, $file);
-        }
+      }
+      // else descend into branch
+      foreach ($node as $key => &$value) {
+        $this->extractStrings($value, $pot, $file);
       }
     } elseif ($node==NULL) {
       return;

--- a/src/Parser/PhpTreeParser.php
+++ b/src/Parser/PhpTreeParser.php
@@ -100,10 +100,6 @@ class PhpTreeParser implements ParserInterface {
       } else {
         foreach ($node->args[1]->value->items as &$ts_argument) {
           switch ($ts_argument->key->value) {
-            case 'domain':
-              $pot_entry['domain'] = $ts_argument->value->value;
-              break;
-
             case 'plural':
               // FIXME: Is this really correct or just a workaround? (copied from old implementation)
               unset($pot_entry['msgstr']);
@@ -117,6 +113,7 @@ class PhpTreeParser implements ParserInterface {
               break;
             
             default:
+            case 'domain':
             case 'count':
             case 'escape':
               break;

--- a/src/Parser/PhpTreeParser.php
+++ b/src/Parser/PhpTreeParser.php
@@ -78,12 +78,12 @@ class PhpTreeParser implements ParserInterface {
 
     // verify the call:
     if (!isset($node->args[0])) {
-      $this->reportError("ts() call has no arguments.", 'error',  $file);
+      $this->reportError("ts() call has no arguments.", 'error',  $file, $node->getLine());
       return;
     }
 
     if (get_class($node->args[0]->value) != 'PhpParser\Node\Scalar\String_') {
-      $this->reportError("first argument of ts() call is no string.", 'warn',  $file);
+      $this->reportError("first argument of ts() call is no string.", 'warn',  $file, $node->getLine());
       return;
     }
 
@@ -94,7 +94,7 @@ class PhpTreeParser implements ParserInterface {
     // process the arguments
     if (isset($node->args[1])) {
       if (get_class($node->args[1]->value) != 'PhpParser\Node\Expr\Array_') {
-        $this->reportError("second argument of ts() call is not an array.", 'warn',  $file);
+        $this->reportError("second argument of ts() call is not an array.", 'warn', $file, $node->getLine());
       } else {
         foreach ($node->args[1]->value->items as &$ts_argument) {
           switch ($ts_argument->key->value) {
@@ -130,12 +130,12 @@ class PhpTreeParser implements ParserInterface {
    * @param string level      severity, on of 'error', 'warn', 'info'
    * @param string reference  location of the error, e.g. the file
    */
-  protected function reportError($message, $level = 'error', $reference = NULL) {
+  protected function reportError($message, $level = 'error', $file = NULL, $line = 'n/a') {
     // TODO: find proper sink for error messages
-    if ($reference) {
-      fwrite(STDERR, "[$level] $message ($reference)");
+    if ($file) {
+      fwrite(STDERR, "[$level] $message ($file:$line)\n");
     } else {
-      fwrite(STDERR, "[$level] $message");
+      fwrite(STDERR, "[$level] $message\n");
     }
   }
 }

--- a/src/Parser/PhpTreeParser.php
+++ b/src/Parser/PhpTreeParser.php
@@ -44,19 +44,17 @@ class PhpTreeParser implements ParserInterface {
       foreach ($node as &$single_node) {
         $this->extractStrings($single_node, $pot, $file);
       }
+    } elseif (is_scalar($node)) {
+      return;
     } elseif (is_object($node)) {
-      if (isset($node->expr)) {
-        $this->extractStrings($node->expr, $pot, $file);
-      }
-      if (isset($node->exprs)) {
-        $this->extractStrings($node->exprs, $pot, $file);
-      }
-      if (isset($node->args)) {
-        $this->extractStrings($node->exprs, $pot, $file);
-      }
       if (get_class($node) == "PhpParser\Node\Expr\FuncCall" && $node->name->parts[0] == 'ts') {
         // this is a 'ts' function call
         $this->createPOTEntry($node, $pot, $file);
+      } else {
+        // else descend into branch
+        foreach ($node as $key => &$value) {
+          $this->extractStrings($value, $pot, $file);
+        }
       }
     } elseif ($node==NULL) {
       return;

--- a/src/Parser/PhpTreeParser.php
+++ b/src/Parser/PhpTreeParser.php
@@ -51,7 +51,7 @@ class PhpTreeParser implements ParserInterface {
         // this is a 'ts' function call
         $this->createPOTEntry($node, $pot, $file);
       }
-      // else descend into branch
+      // in any way: descend into subtree
       foreach ($node as $key => &$value) {
         $this->extractStrings($value, $pot, $file);
       }

--- a/src/Pot.php
+++ b/src/Pot.php
@@ -94,11 +94,13 @@ class Pot {
       $files = trim($files);
       $buf .= "#: $files\n";
 
+      // msgid should go first after files
+      $buf .= "msgid " . $this->escapeString($string['msgid']) . "\n";
+
       foreach ($string as $k => $v) {
         switch ($k) {
+          case 'msgid':
           case 'files':
-            break;
-
           case 'weight':
             break;
 

--- a/src/Pot.php
+++ b/src/Pot.php
@@ -94,12 +94,18 @@ class Pot {
       $files = trim($files);
       $buf .= "#: $files\n";
 
-      // msgid should go first after files
+      // msgctxt should go first after files if exists
+      if (isset($string['msgctxt'])) {
+        $buf .= "msgctxt " . $this->escapeString($string['msgctxt']) . "\n";
+      }
+
+      // ...then msgid
       $buf .= "msgid " . $this->escapeString($string['msgid']) . "\n";
 
       foreach ($string as $k => $v) {
         switch ($k) {
           case 'msgid':
+          case 'msgctxt':
           case 'files':
           case 'weight':
             break;


### PR DESCRIPTION
I created a new AST-based implementation of the ``PhpParser``. The unit tests pass on my system and a comparison with the old parser revealed over 36 *more* detected strings.

I also added support for ``msgctxt``, so I can go ahead and introduce context with some of the strings.