### PR TITLE
Enable civistrings to parse new E::ts() function calls

### DIFF
--- a/src/Parser/PhpTreeParser.php
+++ b/src/Parser/PhpTreeParser.php
@@ -50,6 +50,9 @@ class PhpTreeParser implements ParserInterface {
       if (get_class($node) == "PhpParser\Node\Expr\FuncCall" && $node->name->parts[0] == 'ts') {
         // this is a 'ts' function call
         $this->createPOTEntry($node, $pot, $file);
+      } elseif ($node->name == 'ts' && $node->class->parts[0] == 'E') {
+        // detects the new E::ts() style translations
+        $this->createPOTEntry($node, $pot, $file);
       }
       // in any way: descend into subtree
       foreach ($node as $key => &$value) {


### PR DESCRIPTION
The ``E::ts()`` translation function in ``civix`` to better support extension translations are great, but so far the parser doesn't pick them up - unless I'm mistaken.

This patch should fix this. It did for me, anyway.