### PR TITLE
civicrm/civistrings#9 - Update php-parser for php 8.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "GPL-2+",
     "require": {
         "symfony/console": "~2.3",
-        "nikic/php-parser": "~4.10.2"
+        "nikic/php-parser": "~4.13.2"
     },
     "authors": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "6c09ccb9e1493f6c706b9703eb4e8646",
+    "content-hash": "c1554ff7b817b429881f612bc5aebb18",
     "packages": [
         {
             "name": "nikic/php-parser",
-            "version": "v4.10.2",
+            "version": "v4.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "658f1be311a230e0907f5dfe0213742aff0596de"
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/658f1be311a230e0907f5dfe0213742aff0596de",
-                "reference": "658f1be311a230e0907f5dfe0213742aff0596de",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/210577fe3cf7badcc5814d99455df46564f3c077",
+                "reference": "210577fe3cf7badcc5814d99455df46564f3c077",
                 "shasum": ""
             },
             "require": {
@@ -56,7 +56,11 @@
                 "parser",
                 "php"
             ],
-            "time": "2020-09-26T10:30:38+00:00"
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.2"
+            },
+            "time": "2021-11-30T19:35:32+00:00"
         },
         {
             "name": "symfony/console",
@@ -538,5 +542,5 @@
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.2.0"
 }


### PR DESCRIPTION
Issue https://github.com/civicrm/civistrings/issues/9

I ran on CRM and templates using php 7.4 before the patch to get some output. Then compared the results after the patch using 7.4, 8.0, and 8.1. The resulting pot files are identical.

Both php 8.0 and 8.1 give a bunch of warnings on CRM, but they are just warnings different from the reported fail, and I expect are because of issues in the civi code, e.g. `PHP Warning:  Undefined property: PhpParser\Node\Expr\Variable::$parts in C:\apps\civistrings\src\Parser\PhpTreeParser.php on line 50`