### PR TITLE
Skip *.civix.php files to avoid ts warnings

### DIFF
--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -136,6 +136,11 @@ class ExtractCommand extends Command {
         }
       }
       elseif (file_exists($path)) {
+        // civix files will throw warnings and should not have any strings
+        $filename = basename($path);
+        if (preg_match('/^.+\.civix.php$/', $filename)) {
+          continue;
+        }
         $actualFiles[] = $path;
       }
     }


### PR DESCRIPTION
Example, if I do:

```
$ civistrings ext/civigrant/ > /dev/null
[warn] first argument of ts() call is no string. (ext/civigrant/civigrant.civix.php:31)
```

This warning can be ignored because it's the following code:

```
  public static function ts($text, $params = []) {
    if (!array_key_exists('domain', $params)) {
      $params['domain'] = [self::LONG_NAME, NULL];
    }
    return ts($text, $params);  // <----------- here
  }
```

Usually we scan extensions by scanning the entire directory (either manually, or via tools run by the c-i infra).