### PR TITLE
Avoid notices for $func() notation

### DIFF
--- a/src/Parser/PhpTreeParser.php
+++ b/src/Parser/PhpTreeParser.php
@@ -47,7 +47,7 @@ class PhpTreeParser implements ParserInterface {
     } elseif (is_scalar($node)) {
       return;
     } elseif (is_object($node)) {
-      if (get_class($node) == "PhpParser\Node\Expr\FuncCall" && $node->name->parts[0] == 'ts') {
+      if (get_class($node) == "PhpParser\Node\Expr\FuncCall" && ($node->name->parts[0] ?? '') == 'ts') {
         // this is a 'ts' function call
         $this->createPOTEntry($node, $pot, $file);
       } elseif (get_class($node) == "PhpParser\Node\Expr\StaticCall" && $node->name == 'ts' && $node->class->parts[0] == 'E') {


### PR DESCRIPTION
The new mixins make use of notation like `$callback()` or even `(require $polyfill)(E::LONG_NAME, E::SHORT_NAME, E::path());`. In this situation there is no `name->parts` element so it gives a warning.

I'm assuming it's not necessary to think too much about the case where someone has done:

```php
$ts = 'ts';
echo $ts('String to be translated');
```
