### PR TITLE
Extractor for SK managed file which have implicit ts

### DIFF
--- a/examples/sk1.mgd.php
+++ b/examples/sk1.mgd.php
@@ -1,0 +1,130 @@
+<?php
+
+return [
+  [
+    'name' => 'SavedSearch_Queues',
+    'entity' => 'SavedSearch',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Queues',
+        'label' => ts('Queues (SavedSearch label with ts)'),
+        'api_entity' => 'Queue',
+        'api_params' => [
+          'version' => 4,
+          'select' => [
+            'id',
+            'name',
+            'type:label',
+            'status:label',
+          ],
+          'orderBy' => [],
+          'where' => [],
+          'groupBy' => [],
+          'join' => [],
+          'having' => [],
+        ],
+      ],
+      'match' => [
+        'name',
+      ],
+    ],
+  ],
+  [
+    'name' => 'SavedSearch_Queues_SearchDisplay_Queues_Table_1',
+    'entity' => 'SearchDisplay',
+    'cleanup' => 'always',
+    'update' => 'unmodified',
+    'params' => [
+      'version' => 4,
+      'values' => [
+        'name' => 'Queues_Table_1',
+        'label' => ts('Queues Table (SearchDisplay label with ts)'),
+        'saved_search_id.name' => 'Queues',
+        'type' => 'table',
+        'settings' => [
+          'description' => NULL,
+          'sort' => [],
+          'limit' => 50,
+          'pager' => [],
+          'placeholder' => 5,
+          'columns' => [
+            [
+              'type' => 'field',
+              'key' => 'id',
+              'label' => 'System Queue ID (label)',
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'name',
+              'label' => 'Name (label)',
+              'sortable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'status:label',
+              'label' => 'Status (label)',
+              'sortable' => TRUE,
+              'rewrite' => '',
+              'editable' => TRUE,
+            ],
+            [
+              'type' => 'field',
+              'key' => 'created_id.display_name',
+              'label' => 'Created By (label)',
+              'sortable' => TRUE,
+              'link' => [
+                'path' => '',
+                'entity' => 'Contact',
+                'action' => 'view',
+                'join' => 'created_id',
+                'target' => '_blank',
+              ],
+              'title' => 'View Queue Contact (title)',
+            ],
+            [
+              'size' => 'btn-xs',
+              'links' => [
+                [
+                  'entity' => 'Queue',
+                  'action' => 'view',
+                  'join' => '',
+                  'target' => 'crm-popup',
+                  'icon' => 'fa-external-link',
+                  'text' => 'View Queue (text)',
+                  'style' => 'default',
+                  'path' => '',
+                  'task' => '',
+                  'condition' => [],
+                ],
+              ],
+            ],
+          ],
+          'toolbar' => [
+            [
+              'entity' => 'Queue',
+              'action' => 'add',
+              'target' => 'crm-popup',
+              'icon' => 'fa-plus',
+              'text' => 'Add Queue (text)',
+              'style' => 'primary',
+            ],
+          ],
+          'classes' => [
+            'table',
+            'table-striped',
+            'crm-sticky-header',
+          ],
+        ],
+      ],
+      'match' => [
+        'saved_search_id',
+        'name',
+      ],
+    ],
+  ],
+];
+

--- a/examples/sk1.pot
+++ b/examples/sk1.pot
@@ -1,0 +1,36 @@
+#: examples/sk1.mgd.php
+msgid "Queues (SavedSearch label with ts)"
+msgstr ""
+
+#: examples/sk1.mgd.php
+msgid "Queues Table (SearchDisplay label with ts)"
+msgstr ""
+
+#: examples/sk1.mgd.php
+msgid "System Queue ID (label)"
+msgstr ""
+
+#: examples/sk1.mgd.php
+msgid "Name (label)"
+msgstr ""
+
+#: examples/sk1.mgd.php
+msgid "Status (label)"
+msgstr ""
+
+#: examples/sk1.mgd.php
+msgid "Created By (label)"
+msgstr ""
+
+#: examples/sk1.mgd.php
+msgid "View Queue Contact (title)"
+msgstr ""
+
+#: examples/sk1.mgd.php
+msgid "View Queue (text)"
+msgstr ""
+
+#: examples/sk1.mgd.php
+msgid "Add Queue (text)"
+msgstr ""
+

--- a/src/Command/ExtractCommand.php
+++ b/src/Command/ExtractCommand.php
@@ -5,6 +5,7 @@ use Civi\Strings\Parser\JsParser;
 use Civi\Strings\Parser\PhpTreeParser;
 use Civi\Strings\Parser\SmartyParser;
 use Civi\Strings\Parser\SettingParser;
+use Civi\Strings\Parser\MgdPhpParser;
 use Civi\Strings\Pot;
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Helper\ProgressBar;
@@ -60,6 +61,7 @@ class ExtractCommand extends Command {
     $this->parsers = array();
     $this->parsers['js'] = new JsParser();
     $this->parsers['html'] = new JsParser();
+    $this->parsers['managed'] = new MgdPhpParser();
     $this->parsers['php'] = new PhpTreeParser();
     $this->parsers['smarty'] = new SmartyParser($this->parsers['php']);
     $this->parsers['setting'] = new SettingParser();
@@ -203,6 +205,9 @@ class ExtractCommand extends Command {
     }
     elseif (preg_match('/\.(tpl|hlp)$/', $file)) {
       $parser = 'smarty';
+    }
+    elseif (preg_match('/\.mgd\.php$/', $file)) {
+      $parser = 'managed';
     }
     elseif (preg_match('/\.php$/', $file) || preg_match(':^<\?php:', $content) || preg_match(':^#![^\n]+php:', $content)) {
       $parser = 'php';

--- a/src/Parser/MgdPhpParser.php
+++ b/src/Parser/MgdPhpParser.php
@@ -1,0 +1,73 @@
+<?php
+
+namespace Civi\Strings\Parser;
+
+use Civi\Strings\Pot;
+
+// avoid errors
+function ts($string) {}
+
+class MgdPhpParser extends PhpTreeParser implements ParserInterface {
+
+  /**
+   * On top of regular ts parsing, auto-add strings that are assumed to be multilingual
+   *
+   * @param string $file
+   * @param string $content
+   * @param Pot $pot
+   */
+  public function parse($file, $code, Pot $pot) {
+
+    // Extract raw tokens
+    $lexer = new \PhpParser\Lexer\Emulative();
+    $parser = (new \PhpParser\ParserFactory)->create(\PhpParser\ParserFactory::PREFER_PHP7, $lexer);
+    try {
+      // match all calls to ts()
+      $stmts = $parser->parse($code);
+      $this->extractStrings($stmts, $pot, $file);
+
+      $keys = ['label', 'title', 'text'];
+      $this->extractMgdStrings($stmts, $keys, $pot, $file);
+    }
+    catch (\PhpParser\Error $e) {
+      $this->reportError("Couldn't parse file: " . $e->getMessage(), 'error', $file);
+    }
+
+  }
+
+  protected function extractMgdStrings($node, array $keys, Pot $pot, &$file) {
+    if (is_array($node)) {
+      foreach ($node as &$single_node) {
+        $this->extractMgdStrings($single_node, $keys, $pot, $file);
+      }
+    }
+    elseif (is_scalar($node)) {
+      return;
+    }
+    elseif (is_object($node)) {
+      if (get_class($node) == "PhpParser\Node\Expr\ArrayItem") {
+        if (!empty($node->key->value) && !empty($node->value->value) 
+          && is_scalar($node->key->value) && in_array($node->key->value, $keys) 
+          && is_scalar($node->value->value) && $this->isWorthy($node->value->value)) {
+          $pot->add([
+            'file' => $file,
+            'msgid' => stripcslashes($node->value->value),
+            'msgstr' => '',
+          ]);
+        }
+      }
+
+      foreach ($node as $key => &$value) {
+        $this->extractMgdStrings($value, $keys, $pot, $file);
+      }
+    }
+    elseif ($node == NULL) {
+      return;
+    }
+  }
+
+  protected function isWorthy($value): bool {
+    return !empty($value);
+  }
+
+}

--- a/tests/Command/ExtractCommandTest.php
+++ b/tests/Command/ExtractCommandTest.php
@@ -21,6 +21,7 @@ class ExtractCommandTest extends \PHPUnit\Framework\TestCase {
     $cases[] = array(array("examples/ex4.cmd", "examples/ex4.hlp", "examples/ex4.install", "examples/ex4.module", "examples/ex4.tpl", "examples/ex4.js", "examples/ex4.cmd2", "examples/ex4.txt"), "examples/ex4.pot");
     $cases[] = array(array("examples/ex5.html"), "examples/ex5.pot");
     $cases[] = array(array("examples/Event.setting.php"), "examples/event.setting.pot");
+    $cases[] = array(array("examples/sk1.mgd.php"), "examples/sk1.mgd.pot");
 
     return $cases;
   }

--- a/tests/Command/ExtractCommandTest.php
+++ b/tests/Command/ExtractCommandTest.php
@@ -21,7 +21,7 @@ class ExtractCommandTest extends \PHPUnit\Framework\TestCase {
     $cases[] = array(array("examples/ex4.cmd", "examples/ex4.hlp", "examples/ex4.install", "examples/ex4.module", "examples/ex4.tpl", "examples/ex4.js", "examples/ex4.cmd2", "examples/ex4.txt"), "examples/ex4.pot");
     $cases[] = array(array("examples/ex5.html"), "examples/ex5.pot");
     $cases[] = array(array("examples/Event.setting.php"), "examples/event.setting.pot");
-    $cases[] = array(array("examples/sk1.mgd.php"), "examples/sk1.mgd.pot");
+    $cases[] = array(array("examples/sk1.mgd.php"), "examples/sk1.pot");
 
     return $cases;
   }


### PR DESCRIPTION
Complement to https://github.com/civicrm/civicrm-core/pull/33901 where we remove ts from SK managed files to make string translatable dynamically.

We need to change the extractor to get those strings in transifex even if they don't have `ts()` anymore.