### PR TITLE
Extract 'plural' strings from clientside ts()

### DIFF
--- a/examples/ex1.php
+++ b/examples/ex1.php
@@ -29,11 +29,12 @@ $s2 = ts('%3 – a plural test, %count frog', array(
   "plural" => 'a plural test, %count frogs',
   3 => 'three'
 ));
+$s3 = ts('Inline plural test', ['plural' => '%count tests']);
 //$s3 = ts('a test – no count', array('plural' => 'No count here'));
 //$s4 = ts('a test – no plural', array('count' => 42));
 $s5 = ts('a test for multitoken element value', array(1 => $c . $d));
 $t1 = ts("This is some text with context", array('context' => 'testcontext'));
-$t2 = ts("This is some text with %1 context", array('context' => 'other_context', 1 => 'more'));
+$t2 = ts("This is some text with %1 context", ['context' => 'other_context', 1 => 'more']);
 $t3 = ts("This is some text %1 context", array(1 => 'with even more', 'context' => 'testcontext'));
 
 $ext1 = E::ts('The string from the extension');

--- a/examples/ex1.pot
+++ b/examples/ex1.pot
@@ -53,6 +53,12 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: examples/ex1.php
+msgid "Inline plural test"
+msgid_plural "%count tests"
+msgstr[0] ""
+msgstr[1] ""
+
+#: examples/ex1.php
 msgid "a test for multitoken element value"
 msgstr ""
 

--- a/examples/ex2.js
+++ b/examples/ex2.js
@@ -1,7 +1,7 @@
 alert("Ignore first");
-alert(ts("First"));
+alert(ts("First" ));
 alert(ts("Second", {1: "whiz"}));
-alert(ts('Third'));
+alert(ts( 'Third'));
 alert(clients("Ignore second"));
 alert(clients("Ignore third", {1: "whiz"}));
 function whits() {
@@ -11,12 +11,19 @@ function whits() {
     });
   }
 }
-alert(ts("Fifth") + "-" + ts("Sixth"));
+alert(ts( "Fifth") + "-" + ts("Sixth"));
 alert(ts(message));
 alert(ts("Embedded ts(\'example\')"));
 ts("Special\ncharacters");
 ts('Special\ncharacters');
 ts("more \$special characters");
-ts('even more \\$special characters');
+ts('even more \\$special characters', {});
 ts("Mixed 'quote' \"marks\"");
 ts('Mixed "quote" \'marks\'');
+{
+  ts('Singular', {count: 2, plural: "Plurals %count"});
+}
+ts("Singular %1", {
+  "plural": "Plurals %1 %count",
+  "1": "1",
+});

--- a/examples/ex2.pot
+++ b/examples/ex2.pot
@@ -46,3 +46,15 @@ msgstr ""
 msgid "Mixed \"quote\" 'marks'"
 msgstr ""
 
+#: examples/ex2.js
+msgid "Singular"
+msgid_plural "Plurals %count"
+msgstr[0] ""
+msgstr[1] ""
+
+#: examples/ex2.js
+msgid "Singular %1"
+msgid_plural "Plurals %1 %count"
+msgstr[0] ""
+msgstr[1] ""
+


### PR DESCRIPTION
This supports the new feature added in https://github.com/civicrm/civicrm-core/pull/34362