### PR TITLE
mgd.php extractor add empty_value and rewrite support

### DIFF
--- a/examples/sk1.mgd.php
+++ b/examples/sk1.mgd.php
@@ -52,23 +52,25 @@ return [
           'placeholder' => 5,
           'columns' => [
             [
-              'type' => 'field',
+              'type' => 'html',
               'key' => 'id',
               'label' => 'System Queue ID (label)',
               'sortable' => TRUE,
+              'rewrite' => 'This should be extracted despite containing <b>html</b> (rewrite)'
             ],
             [
               'type' => 'field',
               'key' => 'name',
               'label' => 'Name (label)',
               'sortable' => TRUE,
+              'empty_value' => '(empty_value)'
             ],
             [
               'type' => 'field',
               'key' => 'status:label',
               'label' => 'Status (label)',
               'sortable' => TRUE,
-              'rewrite' => '',
+              'rewrite' => '[status:label] rewrite',
               'editable' => TRUE,
             ],
             [

--- a/examples/sk1.pot
+++ b/examples/sk1.pot
@@ -11,11 +11,23 @@ msgid "System Queue ID (label)"
 msgstr ""
 
 #: examples/sk1.mgd.php
+msgid "This should be extracted despite containing <b>html</b> (rewrite)"
+msgstr ""
+
+#: examples/sk1.mgd.php
 msgid "Name (label)"
 msgstr ""
 
 #: examples/sk1.mgd.php
+msgid "(empty_value)"
+msgstr ""
+
+#: examples/sk1.mgd.php
 msgid "Status (label)"
+msgstr ""
+
+#: examples/sk1.mgd.php
+msgid "[status:label] rewrite"
 msgstr ""
 
 #: examples/sk1.mgd.php

--- a/src/Parser/MgdPhpParser.php
+++ b/src/Parser/MgdPhpParser.php
@@ -11,6 +11,7 @@ class MgdPhpParser extends PhpTreeParser implements ParserInterface {
 
   /**
    * On top of regular ts parsing, auto-add strings that are assumed to be multilingual
+   * similar to ext/search_kit/Civi/Search/Translator.php::updateSearchDisplaySources
    *
    * @param string $file
    * @param string $content
@@ -26,7 +27,7 @@ class MgdPhpParser extends PhpTreeParser implements ParserInterface {
       $stmts = $parser->parse($code);
       $this->extractStrings($stmts, $pot, $file);
 
-      $keys = ['label', 'title', 'text'];
+      $keys = ['label', 'title', 'description', 'text', 'empty_value', 'rewrite'];
       $this->extractMgdStrings($stmts, $keys, $pot, $file);
     }
     catch (\PhpParser\Error $e) {
@@ -35,7 +36,11 @@ class MgdPhpParser extends PhpTreeParser implements ParserInterface {
 
   }
 
-  protected function extractMgdStrings($node, array $keys, Pot $pot, &$file) {
+  /**
+   * Extract string from mgd by going through the array recursively
+   * Similar to ext/search_kit/Civi/Search/Translator.php::extractStrings
+   */
+  protected function extractMgdStrings($node, array $keys, Pot $pot, string &$file) {
     if (is_array($node)) {
       foreach ($node as &$single_node) {
         $this->extractMgdStrings($single_node, $keys, $pot, $file);
@@ -66,8 +71,17 @@ class MgdPhpParser extends PhpTreeParser implements ParserInterface {
     }
   }
 
-  protected function isWorthy($value): bool {
-    return !empty($value);
+  /**
+   * Taken from ext/search_kit/Civi/Search/Translator.php::isWorthy
+   */
+  protected function isWorthy(?string $value): bool {
+    return !empty($value)
+      // ignore value with smarty
+      && !(str_contains($value, '{') && str_contains($value, '}'))
+      // ignore value with custom translation
+      && (!str_contains($value, 'ts('))
+      // ignore value that are a simple field token
+      && !preg_match('/^\[[A-Za-z0-9._-]+\]$/', trim($value));
   }
 
 }


### PR DESCRIPTION
This is a follow-up on:
- https://github.com/civicrm/civistrings/pull/25
- https://github.com/civicrm/civicrm-core/pull/35795
- https://github.com/civicrm/civicrm-core/pull/35860

Add to mgd.php extractor `empty_value` and `rewrite` support as per https://github.com/civicrm/civicrm-core/pull/35860/changes#discussion_r3356537282

Also, the `isWorthy` is updated to be more restrictive the same way we do in https://github.com/civicrm/civicrm-core/pull/35795/changes#diff-28f92e8856eeed4876a3db8314849540334b78d799fcce9411d2be34a021b51fR84